### PR TITLE
Nerf tardis key LP

### DIFF
--- a/src/scripts/replacedRecipes.zs
+++ b/src/scripts/replacedRecipes.zs
@@ -26,7 +26,7 @@ recipes.addShaped(<AWWayofTime:Altar>,
 // TardisMod
 
 recipes.remove(<TardisMod:item.TardisMod.TardisKey>);
-mods.bloodmagic.Altar.addRecipe(<TardisMod:item.TardisMod.TardisKey>, <AwesomeSauceComponents:awesomeCore>, 1, 100000, 15, 15);
+mods.bloodmagic.Altar.addRecipe(<TardisMod:item.TardisMod.TardisKey>, <AwesomeSauceComponents:awesomeCore>, 1, 50000, 15, 15);
 
 
 // ================================================================================


### PR DESCRIPTION
Full inventory of regen 2 potions, while attempting to fight mobs and sacrifice life = near impossible.

Nerfing it to 50k LP still makes it hard, yet actually possible.