### PR TITLE
Remove bash-ism from server start script

### DIFF
--- a/src/_SERVER/ServerStart-Other.sh
+++ b/src/_SERVER/ServerStart-Other.sh
@@ -3,7 +3,7 @@
 cd "$(dirname "$0")"
 
 # Read config
-source config.txt
+. ./config.txt
 
 # makes things easier if script needs debugging
 if [ x$FTB_VERBOSE = xyes ]; then


### PR DESCRIPTION
ServerStart-Other.sh doesn't work if `/bin/sh` isn't an alias for `bash`.  (e.g. Debian and Ubuntu use `dash` instead.)

When the script is run under Bash (even in `sh` compatibility mode), the `source` command will work as an alias for `.`, and it will read files in the current directory.  These behaviors are not actually in the POSIX shell specification.  For compatibility with other `sh` implementations, use the `.` command, and specify an explicit directory on the target file.

(This change works for me on Ubuntu 15.10, where `sh` is `dash`, but I haven't tested it beyond that.  An alternative fix would be to change the first line of the script to `#!/bin/bash`.)