### PR TITLE
Remove diamond recipe from EnderIO

### DIFF
--- a/src/scripts/removedRecipes.zs
+++ b/src/scripts/removedRecipes.zs
@@ -71,3 +71,8 @@ recipes.remove(<chisel:smashingrock>);
 // ================================================================================
 
 print("Initialized 'removedRecipes.zs'");
+
+
+// ================================================================================
+// EnderIO fix. Remove diamond recipe  so opencomputers T3 could be used. Credits to #Печенюх Сергей. 
+recipes.remove(<EnderIO:itemWeatherCrystal);

--- a/src/scripts/removedRecipes.zs
+++ b/src/scripts/removedRecipes.zs
@@ -75,6 +75,3 @@ recipes.remove(<EnderIO:itemWeatherCrystal);
 // ================================================================================
 
 print("Initialized 'removedRecipes.zs'");
-
-
-

--- a/src/scripts/removedRecipes.zs
+++ b/src/scripts/removedRecipes.zs
@@ -69,10 +69,12 @@ recipes.remove(<SolarFlux:solar1>);
 recipes.remove(<chisel:smashingrock>);
 
 // ================================================================================
+// EnderIO fix. Remove diamond recipe  so opencomputers T3 could be used. Credits to #Печенюх Сергей. 
+recipes.remove(<EnderIO:itemWeatherCrystal);
+
+// ================================================================================
 
 print("Initialized 'removedRecipes.zs'");
 
 
-// ================================================================================
-// EnderIO fix. Remove diamond recipe  so opencomputers T3 could be used. Credits to #Печенюх Сергей. 
-recipes.remove(<EnderIO:itemWeatherCrystal);
+


### PR DESCRIPTION
Remove diamond recipe so opencomputers T3 could be used. Credits to #Печенюх Сергей. 
https://github.com/MyM-ModpackTeam/GalacticScience/issues/158